### PR TITLE
Reset the database to initial state before each test

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,5 +6,8 @@ module.exports = defineConfig({
       // implement node event listeners here
     },
     baseUrl: "http://localhost:5173",
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+    },
   },
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,7 +14,15 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+import { database } from "../../src/utils/firebase";
+import { ref, set } from "firebase/database";
+import * as initialData from "../../saved-data/database_export/nushare-2b5ce-default-rtdb.json";
+
+beforeEach(() => {
+  set(ref(database), initialData);
+});

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -31,7 +31,7 @@ const firebase = initializeApp(firebaseConfig);
 const auth = getAuth(firebase);
 const database = getDatabase(firebase);
 
-if (import.meta.env.NODE_ENV !== "production") {
+if (process.env !== "production") {
   connectAuthEmulator(auth, "http://127.0.0.1:9099");
   connectDatabaseEmulator(database, "127.0.0.1", 9001);
   signInWithCredential(
@@ -96,4 +96,4 @@ export const signInWithGoogle = () => {
 };
 
 const firebaseSignOut = () => signOut(getAuth(firebase));
-export { firebaseSignOut as signOut };
+export { firebaseSignOut as signOut, database };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,15 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    "process.env.NODE_ENV": `"${process.env.NODE_ENV}"`,
+  },
+
   plugins: [react()],
   test: {
     globals: true,
-    environment: 'jsdom',
-  }
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
Many unit tests modify data within our firebase emulator database. These changes made during the test remain persistent, and tests are not independent.

For example, consider a test in which a user joins a given ride. When the test is run again, the user already exists in that ride from the previous run, and thus the test fails.

This commit resets the database to prevent such issues and prevent flaky tests. Before each test is executed, the database is set to an initial state containing the original data. As a result, tests remain independent between runs, and tests can be executed repeatedly for an arbitrary number of times without failing.

Based on https://stackoverflow.com/questions/68317339/testing-svelte-components-with-import-meta-env.